### PR TITLE
Add installation of python-xlib via pip.

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -1,6 +1,10 @@
 ##Installation
 You'll need to install python-xlib if you don't have it.
 
+`pip install python-xlib`    
+or `sudo pip install python-xlib` to install `python-xlib` globally.
+
+or use `ubuntu/debian` package manager:
 `sudo apt-get install python-xlib`
 
 Check that you have git installed, and then run this.


### PR DESCRIPTION
`python-xlib` is available on PyPI to be installed with `pip`.

Prefer to use `pip` since it can be installed on any linux distribution not only `ubuntu/debian` based.