### PR TITLE
Add basic mac build github action (#69)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,23 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build-cmake:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest]
+        include:
+        - os: macOS-latest
+          env:
+            CFLAGS: -Wdeclaration-after-statement -Werror
+            CXXFLAGS: -Werror
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build MacOS
+      env: ${{ matrix.env }}
+      run: |
+        cd mac
+        make
+        make install


### PR DESCRIPTION
This will build the keylogger.c file on mac on every pushed commit or pullrequest in this repository.
This won't create any binary artifacts yet and is just a simple ci like travis.