### PR TITLE
Print time in ISO 8601 format on Windows

### DIFF
--- a/windows/klog_main.cpp
+++ b/windows/klog_main.cpp
@@ -136,7 +136,7 @@ int Save(int key_stroke)
 			struct tm tm;
 			localtime_s(&tm, &t);
 			char s[64];
-			strftime(s, sizeof(s), "%c", &tm);
+			strftime(s, sizeof(s), "%FT%X%z", &tm);
 
 			output << "\n\n[Window: " << window_title << " - at " << s << "] ";
 		}


### PR DESCRIPTION
Changes from `Tue Aug 29 13:14:06 2023` to `2023-08-29T13:14:06+0930`