### PR TITLE
Update klog_main.cpp

### DIFF
--- a/windows/klog_main.cpp
+++ b/windows/klog_main.cpp
@@ -130,14 +130,13 @@ int Save(int key_stroke)
 
 		if (strcmp(window_title, lastwindow) != 0)
 		{
-			strcpy(lastwindow, window_title);
-            // get time
-            struct tm* tm_info;
-            time_t t = time(NULL);
-            tm_info = localtime(&t);
-            char s[64];
-            strftime(s, sizeof(s), "%FT%X%z", tm_info);
-
+		    strcpy_s(lastwindow, sizeof(lastwindow), window_title);
+		    // get time
+		    struct tm tm_info;
+		    time_t t = time(NULL);
+		    localtime_s(&tm_info, &t);
+		    char s[64];
+		    strftime(s, sizeof(s), "%FT%X%z", &tm_info);
 
 			output << "\n\n[Window: " << window_title << " - at " << s << "] ";
 		}


### PR DESCRIPTION
strcpy and localtime seem to be deprecated and won't allow to build on VS 2022 without deprecation disabled, probably safer to use strcpy_s and localtime_s